### PR TITLE
Optimize main animation: GPU simulation via FBO ping-pong

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,6 +3,7 @@ import { createThomas } from "./visualizations/thomas";
 import { createThomasWebGL } from "./visualizations/thomas-webgl";
 
 // Any visualization must implement: { init, frame, resize, destroy }
+// WebGL renderer additionally implements setColors(colors) called on theme change.
 // We prefer the WebGL2 renderer; fall back to Canvas 2D if unavailable.
 
 export default function Home() {
@@ -11,8 +12,6 @@ export default function Home() {
   useEffect(() => {
     const canvas = canvasRef.current;
 
-    // Try WebGL2 first. createThomasWebGL.init() returns true on success;
-    // if it returns false we fall back to the Canvas 2D renderer.
     const webglViz = createThomasWebGL();
     const useWebGL = webglViz.init(canvas);
 
@@ -44,14 +43,28 @@ export default function Home() {
     function getColors() {
       const isDark = document.documentElement.getAttribute("data-theme") === "dark";
       return isDark
-        ? { bg: "5,5,8",         litBase: 42, litSpd: 32 }
-        : { bg: "245,242,237",   litBase: 20, litSpd: 25 };
+        ? { bg: "5,5,8",       litBase: 42, litSpd: 32 }
+        : { bg: "245,242,237", litBase: 20, litSpd: 25 };
     }
+
+    // Cache colors; only re-read on theme change via MutationObserver.
+    let cachedColors = getColors();
+    if (useWebGL) viz.setColors(cachedColors);
+
+    const themeObserver = new MutationObserver(() => {
+      cachedColors = getColors();
+      if (useWebGL) viz.setColors(cachedColors);
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
 
     function render() {
       az += (targetAz - az) * 0.06;
       el += (targetEl - el) * 0.06;
-      viz.frame(ctx, W, H, az, el, getColors());
+      // WebGL renderer ignores cachedColors (uses setColors); Canvas 2D uses it.
+      viz.frame(ctx, W, H, az, el, cachedColors);
       animId = requestAnimationFrame(render);
     }
 
@@ -83,6 +96,7 @@ export default function Home() {
 
     return () => {
       cancelAnimationFrame(animId);
+      themeObserver.disconnect();
       viz.destroy();
       window.removeEventListener("mousemove", onMouseMove);
       canvas.removeEventListener("touchmove", onTouchMove);

--- a/src/components/visualizations/thomas-webgl.js
+++ b/src/components/visualizations/thomas-webgl.js
@@ -1,18 +1,13 @@
-// Thomas attractor — WebGL2 renderer.
-// Simulation still runs in JS (it's ~0.5 ms/frame — not the bottleneck).
-// The win is moving projection + styling + rasterization from Canvas 2D (2200
-// stroke() calls, 2200 state flushes) to a single GPU drawcall.
+// Thomas attractor — WebGL2 renderer with FBO ping-pong GPU simulation.
 //
-// Interface: createThomasWebGL() → { init, frame, resize, destroy } | null
-//   Returns null if WebGL2 isn't available so the caller can fall back.
+// Previous version: CPU simulation loop + ~360 KB bufferSubData every frame.
+// This version: simulation runs entirely on GPU via two RGBA32F ping-pong textures
+// (N×TRAIL each). Each frame, a sim pass writes new positions into the idle texture;
+// the draw pass reads from that texture via texelFetch (no position VBO at all).
+// Per-particle hue lives in a static R32F texture (N×1), written once.
+// Speed is stored in the alpha channel of the age-0 row of the position texture.
 //
-// Storage layout is age-major:
-//   positions[(age * N + i) * 3 + k]
-//   age 0  = newest point on the trail
-//   age T-1 = oldest point on the trail
-// Each frame: copyWithin shifts age 0..T-2 → 1..T-1, then we simulate and
-// write the new point at age 0. A single Float32Array memcpy (copyWithin) is
-// much cheaper than a per-particle ring-buffer head.
+// Interface: createThomasWebGL() → { init, setColors, frame, resize, destroy }
 
 const DT = 0.08, B = 0.19;
 const TRAIL = 14;
@@ -27,66 +22,82 @@ function stepParticle(x, y, z, steps) {
   return [x, y, z];
 }
 
-const VERT_SRC = `#version 300 es
+// Simulation pass: renders an N×TRAIL quad; each fragment = one (particle, age) cell.
+// age 0: integrate Thomas attractor step, compute speed → store in alpha.
+// age > 0: copy old age-1 (trail shift).
+const SIM_VERT = `#version 300 es
+void main() {
+  const vec2 p[3] = vec2[3](vec2(-1.,-1.), vec2(3.,-1.), vec2(-1.,3.));
+  gl_Position = vec4(p[gl_VertexID], 0., 1.);
+}`;
+
+const SIM_FRAG = `#version 300 es
 precision highp float;
+precision highp sampler2D;
+uniform sampler2D uOldPos;
+const float DT  = ${DT.toFixed(4)};
+const float B   = ${B.toFixed(4)};
+const int   TM2 = ${TRAIL - 2};
+out vec4 fragColor;
+void main() {
+  ivec2 c        = ivec2(gl_FragCoord.xy);
+  int   particle = c.x;
+  int   age      = c.y;
+  if (age == 0) {
+    vec3  p  = texelFetch(uOldPos, c, 0).xyz;
+    float nx = p.x + (sin(p.y) - B * p.x) * DT;
+    float ny = p.y + (sin(p.z) - B * p.y) * DT;
+    float nz = p.z + (sin(p.x) - B * p.z) * DT;
+    // Speed: dist² from new pos to soon-to-be-oldest (old age TM2 → new age TRAIL-1)
+    vec3  o  = texelFetch(uOldPos, ivec2(particle, TM2), 0).xyz;
+    vec3  d  = vec3(nx, ny, nz) - o;
+    fragColor = vec4(nx, ny, nz, clamp(dot(d, d) * 0.85, 0., 1.));
+  } else {
+    // Trail shift: new age t ← old age t-1
+    fragColor = texelFetch(uOldPos, ivec2(particle, age - 1), 0);
+  }
+}`;
 
-in vec3 aPos;
-
+// Draw pass: no position VBO. gl_VertexID (from EBO) encodes age*N+particle;
+// vertex shader decodes and fetches from the position texture.
+const DRAW_VERT = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uPosTex;   // N×TRAIL RGBA32F: xyz=pos, a=speed (age-0 row only)
+uniform sampler2D uHueTex;   // N×1 R32F: per-particle base hue
 uniform int   uN;
-uniform float uCa, uSa, uCe, uSe;
-uniform float uXScale, uYScale;
-uniform sampler2D uPData; // R=hue/360, G=speed (0..1)
-
+uniform float uCa, uSa, uCe, uSe, uXScale, uYScale;
 flat out float vHue;
 flat out float vSpd;
-
 void main() {
-  // Same camera math as the Canvas 2D version, expressed in clip space:
-  //   projX = W/2 + x1 * (H/11)   →   clipX = x1 * (2H / 11W)
-  //   projY = H/2 - y2 * (H/11)   →   clipY = y2 * (2/11)
-  float x1 = aPos.x * uCa + aPos.z * uSa;
-  float y2 = aPos.y * uCe - (-aPos.x * uSa + aPos.z * uCa) * uSe;
-  gl_Position = vec4(x1 * uXScale, y2 * uYScale, 0.0, 1.0);
+  int age = gl_VertexID / uN;
+  int par = gl_VertexID - age * uN;
+  vec3  pos = texelFetch(uPosTex, ivec2(par, age), 0).xyz;
+  float x1  = pos.x * uCa + pos.z * uSa;
+  float y2  = pos.y * uCe - (-pos.x * uSa + pos.z * uCa) * uSe;
+  gl_Position = vec4(x1 * uXScale, y2 * uYScale, 0., 1.);
+  vHue = texelFetch(uHueTex, ivec2(par, 0), 0).r;
+  vSpd = texelFetch(uPosTex, ivec2(par, 0), 0).a;
+}`;
 
-  // All 14 vertices of a given particle share hue/speed. Layout is age-major,
-  // so (gl_VertexID % N) is the particle index.
-  int pIdx = gl_VertexID - (gl_VertexID / uN) * uN;
-  vec2 pd = texelFetch(uPData, ivec2(pIdx, 0), 0).rg;
-  vHue = pd.r;
-  vSpd = pd.g;
-}
-`;
-
-const FRAG_SRC = `#version 300 es
+const DRAW_FRAG = `#version 300 es
 precision highp float;
-
 flat in float vHue;
 flat in float vSpd;
-
 uniform float uLitBase;
 uniform float uLitSpd;
-
 out vec4 fragColor;
-
-// HSL→RGB (hue in [0,1], s/l in [0,1]). Branchless, standard formulation.
 vec3 hsl2rgb(float h, float s, float l) {
-  vec3 k = clamp(abs(mod(h * 6.0 + vec3(0.0, 4.0, 2.0), 6.0) - 3.0) - 1.0, 0.0, 1.0);
-  float c = (1.0 - abs(2.0 * l - 1.0)) * s;
+  vec3  k = clamp(abs(mod(h * 6. + vec3(0., 4., 2.), 6.) - 3.) - 1., 0., 1.);
+  float c = (1. - abs(2. * l - 1.)) * s;
   return l + c * (k - 0.5);
 }
-
 void main() {
-  // Mirror the Canvas 2D color logic:
-  //   hue  = hueBase + spd * 50       (out of 360)
-  //   lit  = litBase + spd * litSpd   (out of 100)
-  //   alpha = 0.55 + spd * 0.25
-  float hue = vHue + vSpd * (50.0 / 360.0);
-  float lit = (uLitBase + vSpd * uLitSpd) / 100.0;
+  float hue   = vHue + vSpd * (50. / 360.);
+  float lit   = (uLitBase + vSpd * uLitSpd) / 100.;
   float alpha = 0.55 + vSpd * 0.25;
-  vec3 rgb = hsl2rgb(hue, 0.75, lit);
-  fragColor = vec4(rgb, alpha);
-}
-`;
+  fragColor   = vec4(hsl2rgb(hue, 0.75, lit), alpha);
+}`;
 
 function compileShader(gl, type, src) {
   const sh = gl.createShader(type);
@@ -95,20 +106,22 @@ function compileShader(gl, type, src) {
   if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
     const log = gl.getShaderInfoLog(sh);
     gl.deleteShader(sh);
-    throw new Error("shader compile failed: " + log);
+    throw new Error("shader: " + log);
   }
   return sh;
 }
 
-function linkProgram(gl, vs, fs) {
-  const p = gl.createProgram();
-  gl.attachShader(p, vs);
-  gl.attachShader(p, fs);
+function linkProgram(gl, vSrc, fSrc) {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fSrc);
+  const p  = gl.createProgram();
+  gl.attachShader(p, vs); gl.attachShader(p, fs);
   gl.linkProgram(p);
+  gl.deleteShader(vs); gl.deleteShader(fs);
   if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
     const log = gl.getProgramInfoLog(p);
     gl.deleteProgram(p);
-    throw new Error("program link failed: " + log);
+    throw new Error("link: " + log);
   }
   return p;
 }
@@ -116,148 +129,177 @@ function linkProgram(gl, vs, fs) {
 export function createThomasWebGL() {
   let N = 2200;
   let gl = null;
-  let program, vao, posVBO, idxEBO, pDataTex;
-  let uLoc = {};
-  let positions;       // Float32Array, age-major, size TRAIL*N*3
-  let hueBase;         // Float32Array, size N — base hue per particle, 0..1
-  let pData;           // Float32Array, size N*2 — (hue, spd) packed RG
-  let asyncTimers = [];
+  let simProg, drawProg;
+  let simULoc = {}, drawULoc = {};
+  let posTex = [null, null];   // ping-pong RGBA32F N×TRAIL textures
+  let fbo    = [null, null];   // one FBO per texture
+  let hueTex = null;           // static R32F N×1 hue texture
+  let drawVAO = null, idxEBO = null;
+  let ping = 0;                // index of the texture currently holding the latest frame
+
+  // Cached color state — only re-upload uniforms when these change.
+  let bgR = 0, bgG = 0, bgB = 0;
+  let litBase = 42, litSpd = 32;
+  let colorDirty = true;       // litBase/litSpd need uploading to draw shader
+
   let fpsFrames = 0, fpsStart = 0, adapted = false;
 
   function tryGetContext(canvas) {
-    const opts = { alpha: false, antialias: true, premultipliedAlpha: false,
-                   preserveDrawingBuffer: false, powerPreference: "high-performance" };
-    const ctx = canvas.getContext("webgl2", opts);
+    const ctx = canvas.getContext("webgl2", {
+      alpha: false, antialias: true, premultipliedAlpha: false,
+      preserveDrawingBuffer: false, powerPreference: "high-performance",
+    });
     if (!ctx) return null;
-    // Need float textures to store per-particle data.
-    if (!ctx.getExtension("EXT_color_buffer_float")) {
-      // Not strictly needed for sampling, but RG32F textures sometimes require it.
-      // We only SAMPLE the texture, never render to it, so this is usually optional.
-    }
+    // RGBA32F must be renderable for the FBO sim pass.
+    if (!ctx.getExtension("EXT_color_buffer_float")) return null;
     return ctx;
   }
 
-  function allocCPU() {
-    positions = new Float32Array(TRAIL * N * 3);
-    hueBase   = new Float32Array(N);
-    pData     = new Float32Array(N * 2);
+  function makePosTex(data) {
+    const t = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, t);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, N, TRAIL, 0, gl.RGBA, gl.FLOAT, data || null);
+    return t;
   }
 
-  function seedParticles(warmSteps) {
+  function makeFBO(tex) {
+    const f = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, f);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    if (status !== gl.FRAMEBUFFER_COMPLETE) throw new Error("FBO incomplete: " + status);
+    return f;
+  }
+
+  function buildIndices() {
+    // age-major layout: vertex (age t, particle i) = index t*N+i.
+    // Max index = (TRAIL-1)*N + N-1 = 30799 at N=2200 — fits Uint16.
+    const perP = (TRAIL - 1) * 2;
+    const idx  = new Uint16Array(N * perP);
+    let w = 0;
+    for (let i = 0; i < N; i++)
+      for (let t = 0; t < TRAIL - 1; t++) {
+        idx[w++] = t * N + i;
+        idx[w++] = (t + 1) * N + i;
+      }
+    return idx;
+  }
+
+  function seedAndUpload(warmSteps) {
+    const posData = new Float32Array(TRAIL * N * 4);  // RGBA32F, age-major
+    const hueData = new Float32Array(N);
+
     for (let i = 0; i < N; i++) {
       let x = (Math.random() - 0.5) * 4;
       let y = (Math.random() - 0.5) * 4;
       let z = (Math.random() - 0.5) * 4;
       [x, y, z] = stepParticle(x, y, z, warmSteps);
       for (let t = 0; t < TRAIL; t++) {
-        const off = (t * N + i) * 3;
-        positions[off] = x; positions[off + 1] = y; positions[off + 2] = z;
+        const off = (t * N + i) * 4;
+        posData[off] = x; posData[off + 1] = y; posData[off + 2] = z; // alpha = 0 (speed)
       }
-      // Blue → purple band matching the original.
-      hueBase[i] = (180 + ((Math.random() * 130) | 0)) / 360;
-      pData[i * 2]     = hueBase[i];
-      pData[i * 2 + 1] = 0;
+      hueData[i] = (180 + ((Math.random() * 130) | 0)) / 360;
     }
+
+    gl.bindTexture(gl.TEXTURE_2D, posTex[ping]);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, N, TRAIL, 0, gl.RGBA, gl.FLOAT, posData);
+
+    gl.bindTexture(gl.TEXTURE_2D, hueTex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32F, N, 1, 0, gl.RED, gl.FLOAT, hueData);
   }
 
-  // Finish convergence off the critical path.
-  function warmUpAsync() {
-    const EXTRA = 500;
-    const BATCH = 300;
-    let cursor = 0;
-    function chunk() {
-      const end = Math.min(cursor + BATCH, N);
-      for (let i = cursor; i < end; i++) {
-        // Read current newest (age 0), integrate EXTRA steps, fill all trail slots.
-        const idx0 = i * 3;
-        let x = positions[idx0], y = positions[idx0 + 1], z = positions[idx0 + 2];
-        [x, y, z] = stepParticle(x, y, z, EXTRA);
-        for (let t = 0; t < TRAIL; t++) {
-          const off = (t * N + i) * 3;
-          positions[off] = x; positions[off + 1] = y; positions[off + 2] = z;
-        }
-      }
-      cursor = end;
-      if (cursor < N) asyncTimers.push(setTimeout(chunk, 0));
+  // Run `count` simulation steps entirely on GPU via FBO ping-pong.
+  function simulate(count) {
+    gl.useProgram(simProg);
+    gl.disable(gl.BLEND);
+    gl.viewport(0, 0, N, TRAIL);
+    gl.bindVertexArray(null);
+    gl.uniform1i(simULoc.uOldPos, 0);
+
+    for (let i = 0; i < count; i++) {
+      const dst = 1 - ping;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, fbo[dst]);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, posTex[ping]);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+      ping = dst;
     }
-    asyncTimers.push(setTimeout(chunk, 0));
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   }
 
   function buildGPU() {
-    // --- Program ---
-    const vs = compileShader(gl, gl.VERTEX_SHADER, VERT_SRC);
-    const fs = compileShader(gl, gl.FRAGMENT_SHADER, FRAG_SRC);
-    program = linkProgram(gl, vs, fs);
-    gl.deleteShader(vs); gl.deleteShader(fs);
+    simProg  = linkProgram(gl, SIM_VERT, SIM_FRAG);
+    drawProg = linkProgram(gl, DRAW_VERT, DRAW_FRAG);
 
-    uLoc = {
-      uN:       gl.getUniformLocation(program, "uN"),
-      uCa:      gl.getUniformLocation(program, "uCa"),
-      uSa:      gl.getUniformLocation(program, "uSa"),
-      uCe:      gl.getUniformLocation(program, "uCe"),
-      uSe:      gl.getUniformLocation(program, "uSe"),
-      uXScale:  gl.getUniformLocation(program, "uXScale"),
-      uYScale:  gl.getUniformLocation(program, "uYScale"),
-      uPData:   gl.getUniformLocation(program, "uPData"),
-      uLitBase: gl.getUniformLocation(program, "uLitBase"),
-      uLitSpd:  gl.getUniformLocation(program, "uLitSpd"),
+    simULoc = { uOldPos: gl.getUniformLocation(simProg, "uOldPos") };
+
+    drawULoc = {
+      uN:       gl.getUniformLocation(drawProg, "uN"),
+      uPosTex:  gl.getUniformLocation(drawProg, "uPosTex"),
+      uHueTex:  gl.getUniformLocation(drawProg, "uHueTex"),
+      uCa:      gl.getUniformLocation(drawProg, "uCa"),
+      uSa:      gl.getUniformLocation(drawProg, "uSa"),
+      uCe:      gl.getUniformLocation(drawProg, "uCe"),
+      uSe:      gl.getUniformLocation(drawProg, "uSe"),
+      uXScale:  gl.getUniformLocation(drawProg, "uXScale"),
+      uYScale:  gl.getUniformLocation(drawProg, "uYScale"),
+      uLitBase: gl.getUniformLocation(drawProg, "uLitBase"),
+      uLitSpd:  gl.getUniformLocation(drawProg, "uLitSpd"),
     };
 
-    const aPosLoc = gl.getAttribLocation(program, "aPos");
+    posTex[0] = makePosTex(null);
+    posTex[1] = makePosTex(null);
+    fbo[0]    = makeFBO(posTex[0]);
+    fbo[1]    = makeFBO(posTex[1]);
 
-    // --- VAO + VBO + EBO ---
-    vao = gl.createVertexArray();
-    gl.bindVertexArray(vao);
-
-    posVBO = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, posVBO);
-    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
-    gl.enableVertexAttribArray(aPosLoc);
-    gl.vertexAttribPointer(aPosLoc, 3, gl.FLOAT, false, 0, 0);
-
-    idxEBO = gl.createBuffer();
-    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxEBO);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, buildIndices(), gl.STATIC_DRAW);
-
-    gl.bindVertexArray(null);
-
-    // --- Per-particle data texture (RG32F, N × 1) ---
-    pDataTex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, pDataTex);
+    // Static hue texture — data uploaded in seedAndUpload().
+    hueTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, hueTex);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG32F, N, 1, 0, gl.RG, gl.FLOAT, pData);
-  }
 
-  function buildIndices() {
-    // For each particle: (TRAIL - 1) line segments connecting consecutive ages.
-    // Age-major layout → vertex index of (age t, particle i) = t * N + i.
-    // Max index = (TRAIL - 1) * N + (N - 1) — fits in uint16 while N*TRAIL < 65536.
-    // At N = 2200, TRAIL = 14 → max = 30,799. ✓
-    const perP = (TRAIL - 1) * 2;
-    const idx = new Uint16Array(N * perP);
-    let w = 0;
-    for (let i = 0; i < N; i++) {
-      for (let t = 0; t < TRAIL - 1; t++) {
-        idx[w++] = t * N + i;
-        idx[w++] = (t + 1) * N + i;
-      }
-    }
-    return idx;
-  }
-
-  function rebuildBuffers() {
-    // Called after N changes (adaptive quality). Reupload VBO/EBO + texture.
-    gl.bindVertexArray(vao);
-    gl.bindBuffer(gl.ARRAY_BUFFER, posVBO);
-    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
+    // Draw VAO: only an EBO (positions come from texelFetch in vertex shader).
+    drawVAO = gl.createVertexArray();
+    gl.bindVertexArray(drawVAO);
+    idxEBO = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxEBO);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, buildIndices(), gl.STATIC_DRAW);
     gl.bindVertexArray(null);
-    gl.bindTexture(gl.TEXTURE_2D, pDataTex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG32F, N, 1, 0, gl.RG, gl.FLOAT, pData);
+  }
+
+  function rebuildForN() {
+    gl.deleteTexture(posTex[0]); gl.deleteTexture(posTex[1]);
+    gl.deleteFramebuffer(fbo[0]); gl.deleteFramebuffer(fbo[1]);
+    gl.deleteTexture(hueTex);
+
+    posTex[0] = makePosTex(null);
+    posTex[1] = makePosTex(null);
+    fbo[0]    = makeFBO(posTex[0]);
+    fbo[1]    = makeFBO(posTex[1]);
+
+    hueTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, hueTex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.bindVertexArray(drawVAO);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxEBO);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, buildIndices(), gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+
+    ping = 0;
+    seedAndUpload(100);
+    simulate(600);
+    colorDirty = true;
   }
 
   return {
@@ -265,13 +307,16 @@ export function createThomasWebGL() {
       gl = tryGetContext(canvas);
       if (!gl) return false;
       try {
-        allocCPU();
-        seedParticles(100);
         buildGPU();
-        warmUpAsync();
+        ping = 0;
+        seedAndUpload(100);
+        // GPU warm-up: 600 sim passes replaces the async JS warm-up.
+        // These queue immediately and complete before the first rAF fires.
+        simulate(600);
         gl.disable(gl.DEPTH_TEST);
         gl.enable(gl.BLEND);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+        colorDirty = true;
         return true;
       } catch (e) {
         console.warn("WebGL init failed, falling back:", e);
@@ -280,86 +325,67 @@ export function createThomasWebGL() {
       }
     },
 
-    frame(_ctx, W, H, az, el, colors) {
+    // Call once at init and whenever data-theme changes (MutationObserver in Home.jsx).
+    // Parses bg color once instead of every frame.
+    setColors(colors) {
+      const parts = colors.bg.split(",");
+      bgR = +parts[0] / 255; bgG = +parts[1] / 255; bgB = +parts[2] / 255;
+      litBase = colors.litBase;
+      litSpd  = colors.litSpd;
+      colorDirty = true;
+    },
+
+    frame(_ctx, W, H, az, el) {
       if (!gl) return;
 
-      // Adaptive quality: sample 90 frames; halve-ish N if FPS < 38.
+      // Adaptive quality: sample 90 frames; halve N if FPS < 38.
       if (!adapted) {
         if (fpsFrames === 0) fpsStart = performance.now();
-        fpsFrames++;
-        if (fpsFrames === 90) {
+        if (++fpsFrames === 90) {
           const fps = 90000 / (performance.now() - fpsStart);
           if (fps < 38) {
             N = Math.max(600, (N * 0.55) | 0);
-            allocCPU();
-            seedParticles(100);
-            rebuildBuffers();
-            warmUpAsync();
+            rebuildForN();
           }
           adapted = true;
         }
       }
 
-      // --- Simulation (CPU) -------------------------------------------------
-      // Shift the trail: age 0..T-2 → age 1..T-1. Single memcpy.
-      positions.copyWithin(N * 3, 0, (TRAIL - 1) * N * 3);
+      // --- GPU simulation pass (replaces JS loop + bufferSubData) ---
+      simulate(1);
 
-      // Integrate one step for each particle; write new point at age 0.
-      // Compute per-particle speed from (newest - oldest) world distance squared.
-      for (let i = 0; i < N; i++) {
-        const prev = (N + i) * 3;              // previous newest, now at age 1
-        const x = positions[prev], y = positions[prev + 1], z = positions[prev + 2];
-        const nx = x + (Math.sin(y) - B * x) * DT;
-        const ny = y + (Math.sin(z) - B * y) * DT;
-        const nz = z + (Math.sin(x) - B * z) * DT;
-
-        const newest = i * 3;
-        positions[newest]     = nx;
-        positions[newest + 1] = ny;
-        positions[newest + 2] = nz;
-
-        const oldest = ((TRAIL - 1) * N + i) * 3;
-        const dx = nx - positions[oldest];
-        const dy = ny - positions[oldest + 1];
-        const dz = nz - positions[oldest + 2];
-        // Empirically calibrated to match the original's (2D projected delta²
-        // × 0.00015) scaling at the default viewport. Clamp to [0, 1].
-        let spd = (dx * dx + dy * dy + dz * dz) * 0.85;
-        if (spd > 1) spd = 1;
-
-        pData[i * 2]     = hueBase[i];
-        pData[i * 2 + 1] = spd;
-      }
-
-      // --- Upload (GPU) -----------------------------------------------------
-      gl.bindBuffer(gl.ARRAY_BUFFER, posVBO);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, positions);
-
-      gl.bindTexture(gl.TEXTURE_2D, pDataTex);
-      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, N, 1, gl.RG, gl.FLOAT, pData);
-
-      // --- Draw -------------------------------------------------------------
-      // Clear to bg color. colors.bg is "r,g,b" in 0..255.
-      const bgParts = colors.bg.split(",");
-      gl.clearColor(+bgParts[0] / 255, +bgParts[1] / 255, +bgParts[2] / 255, 1);
+      // --- Draw pass ---
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+      gl.clearColor(bgR, bgG, bgB, 1);
       gl.clear(gl.COLOR_BUFFER_BIT);
 
-      gl.useProgram(program);
-      gl.bindVertexArray(vao);
+      gl.useProgram(drawProg);
+      gl.enable(gl.BLEND);
+      gl.bindVertexArray(drawVAO);
 
-      gl.uniform1i(uLoc.uN, N);
-      gl.uniform1f(uLoc.uCa, Math.cos(az));
-      gl.uniform1f(uLoc.uSa, Math.sin(az));
-      gl.uniform1f(uLoc.uCe, Math.cos(el));
-      gl.uniform1f(uLoc.uSe, Math.sin(el));
-      gl.uniform1f(uLoc.uXScale, (2 * H) / (11 * W));
-      gl.uniform1f(uLoc.uYScale, 2 / 11);
-      gl.uniform1f(uLoc.uLitBase, colors.litBase);
-      gl.uniform1f(uLoc.uLitSpd,  colors.litSpd);
+      // Static uniforms: only upload when N or colors change (rare).
+      if (colorDirty) {
+        gl.uniform1i(drawULoc.uN,       N);
+        gl.uniform1i(drawULoc.uPosTex,  0);
+        gl.uniform1i(drawULoc.uHueTex,  1);
+        gl.uniform1f(drawULoc.uLitBase, litBase);
+        gl.uniform1f(drawULoc.uLitSpd,  litSpd);
+        colorDirty = false;
+      }
+
+      // Per-frame uniforms (camera eases continuously).
+      gl.uniform1f(drawULoc.uCa, Math.cos(az));
+      gl.uniform1f(drawULoc.uSa, Math.sin(az));
+      gl.uniform1f(drawULoc.uCe, Math.cos(el));
+      gl.uniform1f(drawULoc.uSe, Math.sin(el));
+      gl.uniform1f(drawULoc.uXScale, (2 * H) / (11 * W));
+      gl.uniform1f(drawULoc.uYScale,  2 / 11);
 
       gl.activeTexture(gl.TEXTURE0);
-      gl.bindTexture(gl.TEXTURE_2D, pDataTex);
-      gl.uniform1i(uLoc.uPData, 0);
+      gl.bindTexture(gl.TEXTURE_2D, posTex[ping]);
+      gl.activeTexture(gl.TEXTURE1);
+      gl.bindTexture(gl.TEXTURE_2D, hueTex);
 
       gl.drawElements(gl.LINES, N * (TRAIL - 1) * 2, gl.UNSIGNED_SHORT, 0);
 
@@ -367,19 +393,18 @@ export function createThomasWebGL() {
     },
 
     resize() {
-      if (!gl) return;
-      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+      // Viewport is set per-frame before drawing.
     },
 
     destroy() {
-      asyncTimers.forEach(clearTimeout);
-      asyncTimers = [];
       if (!gl) return;
-      gl.deleteBuffer(posVBO);
+      gl.deleteTexture(posTex[0]); gl.deleteTexture(posTex[1]);
+      gl.deleteFramebuffer(fbo[0]); gl.deleteFramebuffer(fbo[1]);
+      gl.deleteTexture(hueTex);
       gl.deleteBuffer(idxEBO);
-      gl.deleteVertexArray(vao);
-      gl.deleteTexture(pDataTex);
-      gl.deleteProgram(program);
+      gl.deleteVertexArray(drawVAO);
+      gl.deleteProgram(simProg);
+      gl.deleteProgram(drawProg);
       gl = null;
     },
   };


### PR DESCRIPTION
Move Thomas attractor particle simulation entirely to GPU:
- Two RGBA32F ping-pong textures (N×TRAIL) replace the CPU positions array
- A sim shader runs each frame on the GPU: shifts trail ages and integrates
  the Thomas attractor step in the fragment shader, eliminating the JS
  simulation loop (~6600 Math.sin calls/frame) and the ~360 KB bufferSubData
  upload that was the main per-frame CPU→GPU bottleneck
- Draw vertex shader reads positions via texelFetch (no position VBO)
- Speed stored in alpha channel of age-0 row; hue in a static R32F texture
- 600 GPU warm-up passes in init() replace the async JS warm-up

Cache getColors() with MutationObserver (Home.jsx):
- Colors read from DOM once at init, then only on data-theme changes
- Eliminates DOM attribute read + object allocation every rAF tick
- WebGL renderer notified via setColors(); Canvas 2D fallback uses cached value

Skip redundant static uniform uploads (WebGL renderer):
- uN, uPosTex, uHueTex, uLitBase, uLitSpd only re-uploaded when colorDirty
- Per-frame uniforms (camera angles, scale) still updated every frame

https://claude.ai/code/session_01Ri6UJPLeQnpRpDzm7iotR2