### PR TITLE
Intensify menu overlay blur and add background fade-in

### DIFF
--- a/src/components/MenuOverlay.css
+++ b/src/components/MenuOverlay.css
@@ -49,20 +49,48 @@
   /* top/right/bottom/left set via inline style (JS-computed for pixel-perfect fit) */
   z-index: 500;
   overflow: hidden;
-  /* Hairlines between cells bleed through this background */
-  background: rgba(255, 255, 255, 0.06);
-  /* No fade on open — cells must be visible while sliding in from the edge.
-     A parent opacity transition would hide them mid-slide. */
+  background: transparent;
+}
+
+/* Dark blurred scrim — fades in/out independently from the cells so cells
+   stay at full opacity while sliding. backdrop-filter here blurs the page
+   content behind the entire overlay. */
+.menu-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(24px) saturate(0.75) brightness(0.4);
+  -webkit-backdrop-filter: blur(24px) saturate(0.75) brightness(0.4);
+  z-index: 0;
+  pointer-events: none;
+  animation: overlay-bg-in 0.35s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .menu-overlay--closing {
   pointer-events: none;
 }
 
+.menu-overlay--closing::before {
+  animation: overlay-bg-out 0.42s ease forwards;
+}
+
+@keyframes overlay-bg-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes overlay-bg-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
 /* ══════════════════════════════════════════════
    Bento grid — desktop: 6 equal columns
    ══════════════════════════════════════════════ */
 .menu-grid {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   grid-auto-rows: calc((100vw - 80px) / 6);


### PR DESCRIPTION
Replaces the nearly-transparent overlay background with a ::before
pseudo-element that provides a dark scrim (72% opacity) with strong
backdrop-filter (blur 24px + brightness 0.4). The pseudo-element fades
in/out independently from the bento cells so cells remain at full opacity
during their slide animation. Grid promoted to z-index 1 to stack above
the scrim.

https://claude.ai/code/session_0187D7Vq4UcKD9hhqhckJRUR